### PR TITLE
Migrate extension manifest to Manifest V3 and add background service worker

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,49 @@
+function openDirectoryTab(url) {
+  chrome.tabs.create({ url: url });
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: "last-name-lookup",
+    title: "Last Name Lookup",
+    contexts: ["page", "selection", "image", "link"]
+  });
+
+  chrome.contextMenus.create({
+    id: "first-name-lookup",
+    title: "First Name Lookup",
+    contexts: ["page", "selection", "image", "link"]
+  });
+
+  chrome.contextMenus.create({
+    id: "open-options",
+    title: "Options",
+    contexts: ["selection"]
+  });
+});
+
+chrome.contextMenus.onClicked.addListener((info) => {
+  if (info.menuItemId === "last-name-lookup") {
+    let postUrl = "https://directory.temple.edu/?FN=&LN=";
+
+    if (info.selectionText) {
+      postUrl += encodeURI(info.selectionText);
+    }
+
+    openDirectoryTab(postUrl);
+  }
+
+  if (info.menuItemId === "first-name-lookup") {
+    let postUrl = "https://directory.temple.edu/?FN=";
+
+    if (info.selectionText) {
+      postUrl += encodeURI(info.selectionText) + "&LN=";
+    }
+
+    openDirectoryTab(postUrl);
+  }
+
+  if (info.menuItemId === "open-options") {
+    openDirectoryTab("options.html");
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,19 +1,30 @@
 {
+  "manifest_version": 3,
   "name": "TU Guide",
   "version": "1.0",
   "description": "TU Guide provides resources to use Temple University's website more efficiently.",
-   "icons": {
-      "128": "./images/icon128.png",
-      "48": "./images/icon48.png",
-      "16": "./images/icon16.png"	  
-   },  
-  "browser_action": {
+  "icons": {
+    "128": "./images/icon128.png",
+    "48": "./images/icon48.png",
+    "16": "./images/icon16.png"
+  },
+  "action": {
     "default_icon": "./images/icon16.png",
     "default_title": "Temple University Campus News",
-	"default_popup": "news.html"
+    "default_popup": "news.html"
   },
-  "background_page": "background.html",  
-  "permissions": [ "contextMenus", "tabs", "https://directory.temple.edu/"],
-  "options_page": "options.html"
+  "background": {
+    "service_worker": "background.js"
+  },
+  "permissions": [
+    "contextMenus",
+    "tabs"
+  ],
+  "host_permissions": [
+    "https://directory.temple.edu/*"
+  ],
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  }
 }
-


### PR DESCRIPTION
### Motivation
- Move the extension to Manifest V3 to comply with modern Chromium requirements and avoid MV2 deprecation warnings.
- Replace legacy manifest keys and inline background HTML scripting with MV3 equivalents for consistent behavior across Chrome, Edge, and Brave.
- Keep host access and UI routes compatible with MV3 conventions while preserving existing extension features (context menus, popup, options).

### Description
- Updated `manifest.json` to include `"manifest_version": 3`, replaced `browser_action` with `action`, and replaced `options_page` with `options_ui` pointing to `options.html`.
- Replaced the inline `background_page` pattern with a new service worker file `background.js` and wired it as `background.service_worker` in the manifest.
- Moved site access into `host_permissions` (`https://directory.temple.edu/*`) and kept runtime permissions in `permissions` (`contextMenus`, `tabs`).
- Implemented context-menu creation and click handling in `background.js` to preserve Last Name Lookup, First Name Lookup, and Options behavior.

### Testing
- Validated manifest JSON syntax with `jq . manifest.json`, which completed successfully.
- Confirmed legacy manifest keys are absent and `manifest_version` is present using `rg "browser_action|background_page|options_page|manifest_version" manifest.json`, which returned the expected `manifest_version` line and no legacy key matches.
- Inspected the new `background.js` file to confirm context-menu handlers and URL construction were ported from the former inline script, with no runtime errors reported by static inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac6a8b7bbc83239adc05734548d399)