### PR TITLE
TICKET 2.2: Tighten URL encoding and menu context exposure

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,49 +1,76 @@
-function openDirectoryTab(url) {
-  chrome.tabs.create({ url: url });
+const MAX_SELECTION_LENGTH = 256;
+
+function sanitizeSelection(selectionText) {
+  if (typeof selectionText !== "string") {
+    return "";
+  }
+
+  return selectionText
+    .replace(/[\u0000-\u001F\u007F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_SELECTION_LENGTH);
 }
 
-chrome.runtime.onInstalled.addListener(() => {
-  chrome.contextMenus.create({
-    id: "last-name-lookup",
-    title: "Last Name Lookup",
-    contexts: ["page", "selection", "image", "link"]
+function buildLookupUrl(type, selectionText) {
+  const cleanedSelection = sanitizeSelection(selectionText);
+  const encodedSelection = encodeURIComponent(cleanedSelection);
+
+  if (type === "last-name-lookup") {
+    return `https://directory.temple.edu/?FN=&LN=${encodedSelection}`;
+  }
+
+  if (type === "first-name-lookup") {
+    return `https://directory.temple.edu/?FN=${encodedSelection}&LN=`;
+  }
+
+  return "";
+}
+
+function openDirectoryTab(url) {
+  chrome.tabs.create({ url });
+}
+
+if (typeof chrome !== "undefined" && chrome.runtime && chrome.contextMenus) {
+  chrome.runtime.onInstalled.addListener(() => {
+    chrome.contextMenus.create({
+      id: "last-name-lookup",
+      title: "Last Name Lookup",
+      contexts: ["selection"]
+    });
+
+    chrome.contextMenus.create({
+      id: "first-name-lookup",
+      title: "First Name Lookup",
+      contexts: ["selection"]
+    });
+
+    chrome.contextMenus.create({
+      id: "open-options",
+      title: "Options",
+      contexts: ["action"]
+    });
   });
 
-  chrome.contextMenus.create({
-    id: "first-name-lookup",
-    title: "First Name Lookup",
-    contexts: ["page", "selection", "image", "link"]
-  });
-
-  chrome.contextMenus.create({
-    id: "open-options",
-    title: "Options",
-    contexts: ["selection"]
-  });
-});
-
-chrome.contextMenus.onClicked.addListener((info) => {
-  if (info.menuItemId === "last-name-lookup") {
-    let postUrl = "https://directory.temple.edu/?FN=&LN=";
-
-    if (info.selectionText) {
-      postUrl += encodeURI(info.selectionText);
+  chrome.contextMenus.onClicked.addListener((info) => {
+    if (info.menuItemId === "last-name-lookup") {
+      openDirectoryTab(buildLookupUrl("last-name-lookup", info.selectionText));
     }
 
-    openDirectoryTab(postUrl);
-  }
-
-  if (info.menuItemId === "first-name-lookup") {
-    let postUrl = "https://directory.temple.edu/?FN=";
-
-    if (info.selectionText) {
-      postUrl += encodeURI(info.selectionText) + "&LN=";
+    if (info.menuItemId === "first-name-lookup") {
+      openDirectoryTab(buildLookupUrl("first-name-lookup", info.selectionText));
     }
 
-    openDirectoryTab(postUrl);
-  }
+    if (info.menuItemId === "open-options") {
+      openDirectoryTab("options.html");
+    }
+  });
+}
 
-  if (info.menuItemId === "open-options") {
-    openDirectoryTab("options.html");
-  }
-});
+if (typeof module !== "undefined") {
+  module.exports = {
+    MAX_SELECTION_LENGTH,
+    sanitizeSelection,
+    buildLookupUrl
+  };
+}

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,0 +1,44 @@
+const assert = require('node:assert/strict');
+const {
+  MAX_SELECTION_LENGTH,
+  sanitizeSelection,
+  buildLookupUrl
+} = require('../background.js');
+
+assert.equal(MAX_SELECTION_LENGTH, 256);
+
+assert.equal(sanitizeSelection(undefined), '');
+assert.equal(sanitizeSelection(null), '');
+assert.equal(sanitizeSelection(42), '');
+
+assert.equal(
+  sanitizeSelection('  Alice\n\tSmith  '),
+  'Alice Smith'
+);
+
+assert.equal(
+  sanitizeSelection('A\u0000B\u001FC\u007FD'),
+  'A B C D'
+);
+
+const longSelection = 'x'.repeat(MAX_SELECTION_LENGTH + 20);
+assert.equal(sanitizeSelection(longSelection).length, MAX_SELECTION_LENGTH);
+
+assert.equal(
+  buildLookupUrl('last-name-lookup', 'O\'Connor & Sons'),
+  "https://directory.temple.edu/?FN=&LN=O'Connor%20%26%20Sons"
+);
+
+assert.equal(
+  buildLookupUrl('first-name-lookup', 'Jane/Doe?'),
+  'https://directory.temple.edu/?FN=Jane%2FDoe%3F&LN='
+);
+
+assert.equal(
+  buildLookupUrl('last-name-lookup', '   '),
+  'https://directory.temple.edu/?FN=&LN='
+);
+
+assert.equal(buildLookupUrl('unknown', 'Alice'), '');
+
+console.log('background tests passed');


### PR DESCRIPTION
### Motivation
- Prevent unsafe query handling and accidental data leakage by ensuring selection values are encoded and constrained before use in URLs. 
- Improve user experience by showing lookup options only in the most relevant context (text selection) rather than across pages/images/links. 
- Make selection-based lookup more robust against malformed or malicious input by normalizing and validating selection content and length.

### Description
- Add `MAX_SELECTION_LENGTH` and a `sanitizeSelection` helper that strips control characters, normalizes whitespace, trims, and truncates selections to a safe length. 
- Add `buildLookupUrl` which uses `encodeURIComponent` for query parameter values and centralizes URL construction for both first- and last-name lookups. 
- Restrict the lookup context menu items to `contexts: ["selection"]` and move the Options entry to the extension `action` context, replacing prior page/image/link exposure. 
- Replace inlined URL concatenation with calls to `openDirectoryTab(buildLookupUrl(...))`, export helpers for testing, and add `tests/background.test.js` covering malformed and edge-case inputs.

### Testing
- Ran `node tests/background.test.js`, which executed the unit tests and completed successfully. 
- Unit tests validate non-string inputs, control characters, whitespace normalization, max-length truncation, special-character encoding, blank selections, and unknown lookup types.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8c989ad48323b81ade45d5735868)