### PR TITLE
Minimize extension permissions and add permissions justification docs

### DIFF
--- a/README
+++ b/README
@@ -4,4 +4,8 @@ Tags: Chrome, Temple University
 
 == Description ==
 
-TU Guide - Google Chrome Extension to simplify tasks with the Temple University website
+TU Guide - Google Chrome Extension to simplify tasks with the Temple University website.
+
+## Security and permissions
+
+See `docs/permissions.md` for the Ticket 2.3 permissions minimization review and Chrome Web Store permission-justification draft.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,37 @@
+# Permissions minimization review (Ticket 2.3)
+
+## Current permissions
+
+### Extension permissions
+
+- `contextMenus`
+  - **Why needed:** Required to add the right-click lookup entries (`Last Name Lookup`, `First Name Lookup`) and the action menu item that opens extension options.
+  - **Where used:** `chrome.contextMenus.create(...)` and `chrome.contextMenus.onClicked.addListener(...)` in `background.js`.
+  - **Least-privilege note:** No broader permissions (for example `tabs`) are required for these menu features.
+
+### Host permissions
+
+- `https://news.temple.edu/rss/news/topics/campus-news`
+  - **Why needed:** Allows the popup (`news.html`) to request the official Temple campus news RSS feed.
+  - **Where used:** `fetch(FEED_URL)` in `js/news.js`.
+  - **Least-privilege note:** Scope is restricted to the exact RSS endpoint path instead of a wildcard host.
+
+## Removed permissions and rationale
+
+- Removed `tabs` extension permission.
+  - **Reason:** `chrome.tabs.create({ url })` is used only to open URLs, and this does not require full `tabs` read/access privileges.
+  - **Risk reduction:** Eliminates access to sensitive tab metadata and page details.
+
+- Removed `https://directory.temple.edu/*` host permission.
+  - **Reason:** Directory URLs are opened directly in a tab and not fetched or inspected by extension scripts.
+  - **Risk reduction:** No host access retained where it is not technically required.
+
+## Chrome Web Store listing draft (permission justification)
+
+> **Permission justification draft**
+>
+> TU Guide requests only one extension permission, `contextMenus`, to provide two quick lookup shortcuts from selected text and one action-menu shortcut to open extension options.
+>
+> TU Guide requests a single host permission for `https://news.temple.edu/rss/news/topics/campus-news` so the popup can load Temple's campus news RSS feed.
+>
+> TU Guide does **not** request broad tab-reading access (`tabs`) and does **not** request wildcard host access. All permissions are narrowly scoped to features visible to users.

--- a/manifest.json
+++ b/manifest.json
@@ -17,12 +17,10 @@
     "service_worker": "background.js"
   },
   "permissions": [
-    "contextMenus",
-    "tabs"
+    "contextMenus"
   ],
   "host_permissions": [
-    "https://directory.temple.edu/*",
-    "https://news.temple.edu/*"
+    "https://news.temple.edu/rss/news/topics/campus-news"
   ],
   "options_ui": {
     "page": "options.html",


### PR DESCRIPTION
### Motivation
- Reduce extension privileges to follow least-privilege principles and narrow host scope to only what the extension actually fetches.
- Provide a documented rationale for remaining permissions to support review and Chrome Web Store listing.

### Description
- Removed the unnecessary `tabs` permission from `manifest.json` because `chrome.tabs.create({ url })` does not require full `tabs` access.
- Narrowed `host_permissions` to the exact RSS endpoint `https://news.temple.edu/rss/news/topics/campus-news` used by the popup instead of wildcard host access.
- Added `docs/permissions.md` containing a permissions minimization review, removed-permission rationale, and a Chrome Web Store permission-justification draft.
- Updated `README` to reference `docs/permissions.md` for Ticket 2.3 traceability.

### Testing
- Ran background unit checks with `node tests/background.test.js` and the tests passed (`background tests passed`).
- Verified the updated `manifest.json` parses with `node -e "JSON.parse(require('fs').readFileSync('manifest.json','utf8'))"` and reported valid JSON.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb378210483239f01f008a28e4d41)