### PR TITLE
Rebuild popup/news UX and modernize options page

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -1,10 +1,157 @@
 @charset "UTF-8";
-/* News Style */
+
+:root {
+  color-scheme: light;
+  --text: #1b1b1b;
+  --muted: #4c4c4c;
+  --surface: #ffffff;
+  --surface-alt: #f5f7fa;
+  --border: #d6dde8;
+  --accent: #9d2235;
+  --accent-dark: #7c1b2a;
+  --success: #1f7a3d;
+  --error: #a12622;
+}
+
+* {
+  box-sizing: border-box;
+}
 
 body {
-	width: 400px;
-	font-size: 13px;
-	font-family: Arial, Helvetica, sans-serif;
-	padding: 5px;
-	background-color: #dedede;	
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  color: var(--text);
+  background-color: #eceff3;
+}
+
+.popup-page {
+  width: 400px;
+}
+
+.popup,
+.options {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin: 8px;
+  padding: 12px;
+}
+
+.popup__header,
+.options__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0 0 10px;
+  line-height: 1.3;
+}
+
+h1 {
+  font-size: 1.2rem;
+}
+
+.status {
+  margin: 8px 0 12px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.status[data-tone="success"] {
+  color: var(--success);
+}
+
+.status[data-tone="error"] {
+  color: var(--error);
+  font-weight: 700;
+}
+
+.news-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.news-item {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px;
+  background: var(--surface-alt);
+}
+
+.news-link {
+  display: inline-block;
+  color: #102c57;
+  font-size: 1rem;
+  font-weight: 700;
+  text-decoration-thickness: 2px;
+}
+
+.news-description,
+.feed-source,
+.state-message {
+  margin: 8px 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.feed-source {
+  margin-top: 12px;
+}
+
+.options-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 12px;
+}
+
+.options__tabs {
+  margin: 8px 0 14px;
+}
+
+.button,
+.tab-button {
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  background: var(--accent);
+  color: #fff;
+  padding: 8px 12px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.button--secondary {
+  background: #fff;
+  color: var(--accent-dark);
+}
+
+.button:hover,
+.button:active,
+.tab-button:hover,
+.tab-button:active {
+  background: var(--accent-dark);
+  color: #fff;
+}
+
+.options__panel {
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+a {
+  color: #102c57;
+}
+
+:focus-visible {
+  outline: 3px solid #005fcc;
+  outline-offset: 2px;
 }

--- a/js/news.js
+++ b/js/news.js
@@ -28,33 +28,57 @@ function getItemDescription(item) {
 
 function buildFeedMarkup(channel, items) {
   const channelTitle = channel.querySelector("title")?.textContent?.trim() ?? "Temple News";
-  const channelLink = channel.querySelector("link")?.textContent?.trim() ?? FEED_URL;
 
-  let markup = `<div class="rssHeader"><a href="${escapeHtml(channelLink)}" title="${escapeHtml(channelTitle)}">${escapeHtml(channelTitle)}</a></div>`;
-  markup += '<div class="rssBody"><ul>';
+  let markup = '<ul class="news-list">';
 
-  for (const [index, item] of items.entries()) {
-    const rowClass = index % 2 === 0 ? "odd" : "even";
+  for (const item of items) {
     const title = item.querySelector("title")?.textContent?.trim() ?? "Untitled";
     const link = item.querySelector("link")?.textContent?.trim() ?? FEED_URL;
     const description = getItemDescription(item);
 
-    markup += `<li class="rssRow ${rowClass}">`;
-    markup += `<h4><a href="${escapeHtml(link)}" title="View this story">${escapeHtml(title)}</a></h4>`;
+    markup += '<li class="news-item">';
+    markup += `<a class="news-link" href="${escapeHtml(link)}" title="Open story in new tab">${escapeHtml(title)}</a>`;
 
     if (description) {
-      markup += `<p>${escapeHtml(description)}</p>`;
+      markup += `<p class="news-description">${escapeHtml(description)}</p>`;
     }
 
     markup += "</li>";
   }
 
-  markup += "</ul></div>";
+  markup += "</ul>";
+  markup += `<p class="feed-source">Source: ${escapeHtml(channelTitle)}</p>`;
+
   return markup;
 }
 
+function setStatus(message, tone = "info") {
+  const feedStatus = document.getElementById("feedStatus");
+  if (!feedStatus) {
+    return;
+  }
+
+  feedStatus.textContent = message;
+  feedStatus.dataset.tone = tone;
+}
+
+function setRetryVisible(isVisible) {
+  const retryButton = document.getElementById("retryButton");
+  if (retryButton) {
+    retryButton.hidden = !isVisible;
+  }
+}
+
 async function renderFeed() {
-  const container = document.getElementById("Content");
+  const container = document.getElementById("feedRegion");
+
+  if (!container) {
+    return;
+  }
+
+  container.innerHTML = "";
+  setStatus("Loading latest campus news…", "info");
+  setRetryVisible(false);
 
   try {
     const secureFeedUrl = ensureHttps(FEED_URL);
@@ -66,6 +90,12 @@ async function renderFeed() {
 
     const xmlText = await response.text();
     const xml = new DOMParser().parseFromString(xmlText, "application/xml");
+    const parserError = xml.querySelector("parsererror");
+
+    if (parserError) {
+      throw new Error("Feed response could not be parsed.");
+    }
+
     const channel = xml.querySelector("rss > channel");
 
     if (!channel) {
@@ -75,18 +105,36 @@ async function renderFeed() {
     const entries = [...channel.querySelectorAll("item")].slice(0, MAX_ITEMS);
 
     if (!entries.length) {
-      container.innerHTML = '<div class="rssError"><p>No campus news is currently available.</p></div>';
+      setStatus("No campus news is currently available.", "empty");
+      container.innerHTML = '<p class="state-message">Check back again later for updates.</p>';
       return;
     }
 
+    setStatus(`Showing ${entries.length} recent stories.`, "success");
     container.innerHTML = buildFeedMarkup(channel, entries);
+
     for (const link of container.querySelectorAll("a")) {
       link.target = "_blank";
       link.rel = "noopener noreferrer";
     }
   } catch (error) {
-    container.innerHTML = `<div class="rssError"><p>${escapeHtml(error.message || "Unable to load feed.")}</p></div>`;
+    const message = error?.message || "Unable to load feed.";
+    setStatus(`Could not load campus news: ${message}`, "error");
+    setRetryVisible(true);
+    container.innerHTML = '<p class="state-message">Please check your connection and try again.</p>';
   }
 }
 
-document.addEventListener("DOMContentLoaded", renderFeed);
+function setupPopup() {
+  const retryButton = document.getElementById("retryButton");
+  if (retryButton) {
+    retryButton.addEventListener("click", () => {
+      renderFeed();
+      retryButton.focus();
+    });
+  }
+
+  renderFeed();
+}
+
+document.addEventListener("DOMContentLoaded", setupPopup);

--- a/js/options.js
+++ b/js/options.js
@@ -1,0 +1,27 @@
+function showPage(pageId) {
+  const panels = document.querySelectorAll(".options__panel");
+  const tabButtons = document.querySelectorAll(".tab-button");
+
+  for (const panel of panels) {
+    panel.hidden = panel.id !== pageId;
+  }
+
+  for (const button of tabButtons) {
+    const active = `page-${button.dataset.page}` === pageId;
+    button.setAttribute("aria-current", active ? "page" : "false");
+  }
+}
+
+function initialiseOptionsPage() {
+  const tabButtons = document.querySelectorAll(".tab-button");
+
+  for (const button of tabButtons) {
+    button.addEventListener("click", () => {
+      showPage(`page-${button.dataset.page}`);
+    });
+  }
+
+  showPage("page-about");
+}
+
+document.addEventListener("DOMContentLoaded", initialiseOptionsPage);

--- a/news.html
+++ b/news.html
@@ -1,11 +1,22 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <title>News</title>
-    <link type="text/css" rel="stylesheet" href="css/screen.css" />
-    <script type="text/javascript" src="./js/news.js" defer></script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Temple News</title>
+    <link rel="stylesheet" href="css/screen.css" />
+    <script src="js/news.js" defer></script>
   </head>
-  <body>
-    <div id="Content">Loading campus news…</div>
+  <body class="popup-page">
+    <main id="popup-main" class="popup" aria-labelledby="popup-title">
+      <header class="popup__header">
+        <h1 id="popup-title">Temple Campus News</h1>
+        <button id="retryButton" class="button button--secondary" type="button" hidden>
+          Retry
+        </button>
+      </header>
+      <p id="feedStatus" class="status" role="status" aria-live="polite">Loading latest campus news…</p>
+      <section id="feedRegion" aria-label="Campus news feed" aria-live="polite"></section>
+    </main>
   </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -1,59 +1,35 @@
-﻿<html>
-<head><title>TU Guide</title>
-<!--Author: Leonard Nelson -->
-<!--Website: https://www.leonelson.com -->
-<link rel="stylesheet" type="text/css" href="css/screen.css" />
-<script type="text/javascript">
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TU Guide Options</title>
+    <link rel="stylesheet" href="css/screen.css" />
+    <script src="js/options.js" defer></script>
+  </head>
+  <body class="options-page">
+    <main class="options" aria-labelledby="options-title">
+      <header class="options__header">
+        <h1 id="options-title">TU Guide</h1>
+      </header>
 
-function showpage(page){
-	for(var i=1; i<=3; i++){
-		if(i==page) document.getElementById("page"+i).style.display = "block";
-		else document.getElementById("page"+i).style.display = "none";
-	}	
-}
+      <nav class="options__tabs" aria-label="Options sections">
+        <button type="button" class="tab-button" data-page="about" aria-current="page">About</button>
+      </nav>
 
-</script>
-<script type="text/javascript">
-$(document).ready(function(){ 
-						   
-	$(function() {
-		$("#options_list_ul").sortable({ opacity: 0.3, cursor: 'move', update: function() {
-			console.log("Reordered");
-		}								  
-		});
-	});
+      <section id="page-about" class="options__panel" aria-labelledby="options-title">
+        <h2>Change Log</h2>
+        <p>Version: 1.00</p>
 
-});	
-</script>
-</head>
-<body onLoad="initialise()">
-<div id="container">
-	<div id="header">
-		<div class="left">
-			<h1 class="style1">TU Guide</h1>
-		</div>
-		<div class="right">
-			<button class="top_options" onClick="showpage(1)">About</button>
-		</div>	  
-	   <div class="clear"></div>
-	</div>
-	<hr />
-	<div id="body">
-		<div id="page1">
-			<div class="contain">
-				<h4>Change Log</h4>
-				<p>Version: 1.00</p>
-				<div align="left">
-					<h4>Updates</h4>
-					<p>1.0:  Hello TU Guide - Initial version that includes first name/ last name lookup</p>
-					<h4>Feedback</h4>
-					<p>For suggestions and bug-reports, feel free to <a href="https://www.leonelson.com/contact/" target="_blank">contact me</a>.</p>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div id="footer">
-	</div>
-</div>
-</body>
+        <h3>Updates</h3>
+        <p>1.0: Hello TU Guide - Initial version that includes first name/last name lookup.</p>
+
+        <h3>Feedback</h3>
+        <p>
+          For suggestions and bug reports, feel free to
+          <a href="https://www.leonelson.com/contact/" target="_blank" rel="noopener noreferrer">contact me</a>.
+        </p>
+      </section>
+    </main>
+  </body>
 </html>


### PR DESCRIPTION
### Motivation
- The popup depended on an inline script and an external, brittle feed pipeline so it needed a resilient local implementation with clear loading/empty/error states.
- The options page used inline handlers and an undefined `initialise()` flow causing runtime breakage and accessibility issues.
- A baseline accessibility pass was required to ensure keyboard operability, readable targets, and semantic structure across extension pages.

### Description
- Rebuilt the popup markup into a semantic structure with `<main>`, heading, a live `role="status"` region and a dedicated `Retry` button, and moved logic to `js/news.js` (no inline scripts) (`news.html`, `js/news.js`).
- Implemented resilient feed states in `js/news.js`: `loading`, `empty`, `success`, `error`, parser/response validation, safe external link handling, and retry handling via a bound click listener.
- Modernized `options.html` with `doctype`, `lang`, `charset`, viewport meta, removed inline `onLoad/onClick` usage and replaced initialization with `js/options.js` which binds tab buttons and manages panel visibility.
- Refreshed shared styling in `css/screen.css` to improve readable targets, contrast, focus-visible outlines, and overall a11y-friendly presentation.

### Testing
- Static checks: `node --check js/news.js` and `node --check js/options.js` both passed.
- Unit/automation: `node tests/background.test.js` passed (background tests passed).
- Inline-handler scan: ran `rg` checks to confirm no remaining `onClick`/`onLoad` inline attributes and verified scripts are `defer`-loaded; results showed only the new external script tags.
- End-to-end/keyboard checks: served pages with `python3 -m http.server 4173` and validated via Playwright which reported no page errors and appropriate keyboard focus order (`options_focus: tab-button`, `popup_focus: retryButton`) and produced screenshots of the popup and options pages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acbe68be088323a8c5de1e509d573d)